### PR TITLE
New config and output switching via config

### DIFF
--- a/test-crawler/.gitignore
+++ b/test-crawler/.gitignore
@@ -1,3 +1,4 @@
 _modules
+_local_modules
 outputs
 .vscode

--- a/test-crawler/Makefile
+++ b/test-crawler/Makefile
@@ -1,13 +1,3 @@
 
-
-init:
-	mkdir -p _modules
-	mkdir -p _local_modules
-	if cd _modules/lotus; then git pull; else git clone https://github.com/filecoin-project/lotus/ _modules/lotus; fi
-	if cd _modules/specs-actors; then git pull; else git clone https://github.com/filecoin-project/specs-actors/ _modules/specs-actors; fi
-
-run_origin: init
-	go run *.go
-
 run: 
 	go run *.go

--- a/test-crawler/Makefile
+++ b/test-crawler/Makefile
@@ -1,10 +1,13 @@
 
 
 init:
-	mkdir -p outputs
 	mkdir -p _modules
+	mkdir -p _local_modules
 	if cd _modules/lotus; then git pull; else git clone https://github.com/filecoin-project/lotus/ _modules/lotus; fi
 	if cd _modules/specs-actors; then git pull; else git clone https://github.com/filecoin-project/specs-actors/ _modules/specs-actors; fi
 
-run: init
-	go run main.go
+run_origin: init
+	go run *.go
+
+run: 
+	go run *.go

--- a/test-crawler/README.md
+++ b/test-crawler/README.md
@@ -1,23 +1,25 @@
 
 # Test Crawler
 
-**Description**:  Test Crawler is a tool made to build json file out of project source code  
-that describes test functions and corresponding scenarios  
-Currently its being built for Filecoin  
+**Description**:  Test Crawler is a tool made to build json file or output json to standard output out of project source code  
+that describes test functions and corresponding scenarios   
 
-## Installation
+## Configuration  
 
-Clone repository and run the following in your favorite terminal:  
-``` 
-make init
-make run
-```  
+clone repository that should be annotated  
+
+Create or update config.yaml to suite your needs.  
+Config propperties:  
+*name* - name or list of names of repositories that will be stored in destination folder for annotation parsing  
+*origin* - remote git origin used for cloning or pulling changes  
+*mode* - origin or local.  
+*destination* - Destination specifies the output folder for origin  
+*output* - save TC output to json or print it on stdout  
+*lang_mode* - work in progress    
 
 ## Usage
 
-`make init` will clone filecoin repository (or pull changes if it already exists) in _modules directory  
-It will also pull spec-actors  
-`make run` outputs *json* file in outputs directory  
+`make run`  - runs test crawler 
    
 ----
 Current annotation format examples:  

--- a/test-crawler/config.go
+++ b/test-crawler/config.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Repository struct {
+	Name        []string `yaml:",flow"`
+	Origin      []string `yaml:",flow"`
+	Mode        string   `yaml:"mode"`
+	Destination string   `yaml:"destination"`
+}
+
+type Config struct {
+	Repo       Repository `yaml:"repository"`
+	OutputMode string     `yaml:"output"`
+	Language   string     `yaml:"lang_mode"`
+}
+
+const filename string = "config.yaml"
+
+func NewConfig() Config {
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return Default()
+	}
+	defer file.Close()
+
+	config := Config{}
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return Default()
+	}
+
+	err = yaml.Unmarshal([]byte(content), &config)
+	if err != nil {
+		return Default()
+	}
+
+	return config
+}
+
+func Default() Config {
+	return Config{
+		Repo: Repository{
+			Name:        []string{"lotus", "spec-actors"},
+			Origin:      []string{"https://github.com/filecoin-project/lotus/", "https://github.com/filecoin-project/specs-actors/"},
+			Mode:        "local",
+			Destination: "_local",
+		},
+		OutputMode: "stdout",
+		Language:   "auto",
+	}
+}

--- a/test-crawler/config.go
+++ b/test-crawler/config.go
@@ -7,6 +7,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type OutputMode string
+
+const (
+	MODE_STDOUT OutputMode = "stdout"
+	MODE_FILE   OutputMode = "file"
+)
+
 type Repository struct {
 	Name        []string `yaml:",flow"`
 	Origin      []string `yaml:",flow"`
@@ -16,7 +23,7 @@ type Repository struct {
 
 type Config struct {
 	Repo       Repository `yaml:"repository"`
-	OutputMode string     `yaml:"output"`
+	OutputMode OutputMode `yaml:"output"`
 	Language   string     `yaml:"lang_mode"`
 }
 

--- a/test-crawler/config.go
+++ b/test-crawler/config.go
@@ -55,8 +55,8 @@ func NewConfig() Config {
 func Default() Config {
 	return Config{
 		Repo: Repository{
-			Name:        []string{"lotus", "spec-actors"},
-			Origin:      []string{"https://github.com/filecoin-project/lotus/", "https://github.com/filecoin-project/specs-actors/"},
+			Name:        []string{},
+			Origin:      []string{},
 			Mode:        "local",
 			Destination: "_local",
 		},

--- a/test-crawler/config.yaml
+++ b/test-crawler/config.yaml
@@ -1,0 +1,15 @@
+
+repository: 
+  # names of cloned repositories
+  name: [lotus, spec-actors]
+  # origins for above repositories, need to be in order as in name list
+  origin: [https://github.com/filecoin-project/lotus/, https://github.com/filecoin-project/specs-actors/]
+  # origin or local
+  mode: origin
+  # destination folder, needed for origin mode to clone/pull
+  destination: _modules
+
+# stdout or file(json)
+output: stdout
+# auto or one of the supported languages for specific repo
+lang_mode: auto

--- a/test-crawler/go.mod
+++ b/test-crawler/go.mod
@@ -3,3 +3,5 @@ module testsuites
 go 1.17
 
 require github.com/smacker/go-tree-sitter v0.0.0-20211116060328-db7fde9b5e82
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/test-crawler/go.sum
+++ b/test-crawler/go.sum
@@ -10,3 +10,5 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/test-crawler/main.go
+++ b/test-crawler/main.go
@@ -55,27 +55,36 @@ func main() {
 		files[i].Scenarios = scenarios
 	}
 
-	//SaveToFile(files)
+	Save(files, config.OutputMode)
 }
 
-func SaveToFile(files []c.TestFile) {
-	now := time.Now()
-	timestamp := now.Unix()
-
-	filename := fmt.Sprintf("%s/output_%d.json", OUTPUT_FOLDER, timestamp)
-
-	file, err := os.Create(filename)
-	if err != nil {
-		return
-	}
-	defer file.Close()
+func Save(files []c.TestFile, mode OutputMode) {
 
 	content, err := json.Marshal(files)
 	if err != nil {
 		return
 	}
 
-	file.Write(content)
+	switch mode {
+	case MODE_FILE:
+		now := time.Now()
+		timestamp := now.Unix()
+
+		filename := fmt.Sprintf("%s/output_%d.json", OUTPUT_FOLDER, timestamp)
+
+		file, err := os.Create(filename)
+		if err != nil {
+			return
+		}
+		defer file.Close()
+
+		file.Write(content)
+	case MODE_STDOUT:
+		fmt.Print(string(content))
+	default:
+		fmt.Print(string(content))
+	}
+
 }
 
 func Shell(command string, destination string) (string, string, error) {


### PR DESCRIPTION
## Description

Test crawler now has config in yaml format.
Changes in this PR are not final and are up to discussion.
Config propperties:
* name - name or list of names of repositories that will be stored in destination folder for annotation parsing
* origin - remote git origin used for cloning or pulling changes. This was removed from Makefile,
and it's now integrated in the code itself. The logic is that when TC is used first time, the clone of repositories
happens, and every time that it gets started on that repository it will just update (pull) changes made on origin.
* mode - origin or local. Origin is used when we want remote git to be used, local is used more for testing,
without having to pull remote changes - basically a local repository.
* destination - Destination specifies the output folder for origin, in other words, where to clone git repository.
This is useful if we want to work on different repositories that are not necessarily connected to each other.
By switching destination we can save the previous one and get back to it later if we wish. 
* output - save TC output to json or print it on stdout. Possible properties are "file" and "stdout".
It defaults to stdout.
* lang_mode - unimplemented, it will be used to specify language or set it to "auto" for automatic determination 
based on file extensions in repository.  

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] This change requires a documentation update
- [x] This change requires a configuration update

## How Has This Been Tested?

Tested locally on lotus and spec-actors repository.
Works as espected, however git usage with shell might be a problem for pipeline
if it asks for credentials. git is used with https in code.

## Checklist:

- [x] I have performed a self-review of this code and spelling
- [x] I have added comments in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
