### PR TITLE
rewrite: scraper

### DIFF
--- a/frontend/apps/web/src/model/CI.ts
+++ b/frontend/apps/web/src/model/CI.ts
@@ -1,0 +1,42 @@
+// generated from JSON using https://app.quicktype.io/
+
+export interface CiTest {
+  name: string
+  classname: string
+  result: string
+  source: string
+  job: Job
+}
+
+export interface Job {
+  job_number: number
+  id: string
+  name: string
+  number: number
+  status: string
+  workflow: Workflow
+  url: string
+}
+
+export interface Workflow {
+  id: string
+  name: string
+  status: string
+  pipeline: Pipeline
+}
+
+export interface Pipeline {
+  id: string
+  state: string
+  number: number
+  VCS: Vcs
+  Trigger: Trigger
+}
+
+export interface Trigger {
+  type: string
+}
+
+export interface Vcs {
+  branch: string
+}

--- a/frontend/packages/types/src/test.ts
+++ b/frontend/packages/types/src/test.ts
@@ -16,7 +16,9 @@ export class Test {
     public repository: Repository,
     public kind: TestKind,
     public status,
+    public parentFolder: string,
     public linkedBehaviors: Behavior[] = [],
+    public ciLink: string = '',
   ) {}
 }
 

--- a/scraper/README.md
+++ b/scraper/README.md
@@ -1,0 +1,7 @@
+# CircleCI scraper
+
+The scraper "scrapes" lotus tests and their statuses from the latest CI pipeline, using the CircleCI API, and outputs them to stdout.
+
+- You can run it using `go run circleci_scraper.go`
+- If you want to save the results to a file, you can just do `go run circleci_scraper.go > ci.json`
+

--- a/scraper/circleci_scraper.go
+++ b/scraper/circleci_scraper.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 )
 
 const circleCiApiEndpoint = "https://circleci.com/api/v2"
@@ -60,7 +59,6 @@ type Test struct {
 func circleciApiCall(endpoint string) []byte {
 	url := fmt.Sprintf("%s/%s", circleCiApiEndpoint, endpoint)
 
-	fmt.Println("GET: ", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		panic(err)
@@ -68,15 +66,13 @@ func circleciApiCall(endpoint string) []byte {
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 
 	return body
@@ -91,7 +87,7 @@ func getPipelines(branch string) []Pipeline {
 
 	err := json.Unmarshal(body, &response)
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 
 	return response.Pipelines
@@ -107,7 +103,7 @@ func getCiWorkflow(pline Pipeline) Workflow {
 	err := json.Unmarshal(body, &response)
 
 	if err != nil {
-		fmt.Println(err)
+		panic(err)
 	}
 
 	if len(response.Workflows) != 1 {

--- a/scraper/circleci_scraper.go
+++ b/scraper/circleci_scraper.go
@@ -16,6 +16,8 @@ import (
 )
 
 const circleCiApiEndpoint = "https://circleci.com/api/v2"
+const circleCiUi = "https://app.circleci.com"
+const circleCiProject = "github/filecoin-project/lotus"
 
 type Pipeline struct {
 	ID     string `json:"id"`
@@ -81,7 +83,7 @@ func circleciApiCall(endpoint string) []byte {
 }
 
 func getPipelines(branch string) []Pipeline {
-	body := circleciApiCall(fmt.Sprintf("project/gh/filecoin-project/lotus/pipeline?branch=%s", branch))
+	body := circleciApiCall(fmt.Sprintf("project/%s/pipeline?branch=%s", circleCiProject, branch))
 
 	var response struct {
 		Pipelines []Pipeline `json:"items"`
@@ -142,7 +144,7 @@ func getTests(job Job) []Test {
 		Tests []Test `json:"items"`
 	}
 
-	body := circleciApiCall(fmt.Sprintf("project/gh/filecoin-project/lotus/%d/tests", job.JobNumber))
+	body := circleciApiCall(fmt.Sprintf("project/%s/%d/tests", circleCiProject, job.JobNumber))
 
 	err := json.Unmarshal(body, &response)
 	if err != nil {
@@ -158,7 +160,9 @@ func getTests(job Job) []Test {
 
 func formatJobURL(job Job) string {
 	return fmt.Sprintf(
-		"https://app.circleci.com/pipelines/github/filecoin-project/lotus/%d/workflows/%s/jobs/%d/tests",
+		"%s/pipelines/%s/%d/workflows/%s/jobs/%d/tests",
+		circleCiUi,
+		circleCiProject,
 		job.Workflow.Pipeline.Number,
 		job.Workflow.ID,
 		job.JobNumber,


### PR DESCRIPTION
## Description

I rewrote the scraper to scrape all information needed to create links
to jobs on the CircleCI dashboard.

I didn't find a way to link to specific tests, only to jobs those tests
belong to. I couldn't even find a separate test page in the UI, so I think
this is the best we could do.

Also, now it writes output to stdout, but if you need it in a file, you
can easily pipe the output to a file, I think this is a better approach.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## How Has This Been Tested?

Only manually.

## Checklist:

- [x] I have performed a self-review of this code and spelling
- [x] I have added comments in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

