### PR TITLE
fix: bug with ci links

### DIFF
--- a/frontend/apps/web/src/model/DenormalizedLoader.ts
+++ b/frontend/apps/web/src/model/DenormalizedLoader.ts
@@ -48,11 +48,6 @@ export class DenormalizedLoader implements ModelLoader {
 
     this.calculateSummaryStatistics()
 
-    console.log(Array.from(this.tests.entries())[0])
-    console.log(Array.from(this.ciTests.entries())[0])
-    // console.log(Object.entries(this.tests))
-    // // console.log(Object.entries(this.ciTests)[0])
-
     return {
       systems: this.systems,
       behaviors: this.behaviors,
@@ -191,13 +186,15 @@ export class DenormalizedLoader implements ModelLoader {
         [],
       )
 
-      const ciId = `${testFile.parent_folder}/${rawScenario.function}`
-      const relatedCiTest = this.ciTests.get(ciId)
+      const relatedCiTest = this.ciTests.get(test.functionName)
 
       if (relatedCiTest) {
         test.ciLink = relatedCiTest.job.url
+        if (!['success', 'skipped'].includes(relatedCiTest.result)) {
+          test.status = TestStatus.fail
+        }
       } else {
-        console.error(`Not url for ${ciId}`)
+        console.error(`No url for ${test.functionName}`)
       }
 
       if (rawScenario.Behaviors) {
@@ -284,10 +281,10 @@ export class DenormalizedLoader implements ModelLoader {
 
   private loadCiTests() {
     for (const test of ci as CiTest[]) {
-      const classnameSplit = test.classname.split('/')
-      const parentFolder = classnameSplit.pop()
-      const id = `${parentFolder}/${test.name}`
-      this.ciTests.set(id, test)
+      // look only for top-level tests
+      if (!test.name.includes('/')) {
+        this.ciTests.set(test.name, test)
+      }
     }
   }
 

--- a/frontend/apps/web/src/model/__tests__/helpers.ts
+++ b/frontend/apps/web/src/model/__tests__/helpers.ts
@@ -82,6 +82,10 @@ export function testTestIntegrity(test: Test) {
   if (test.status === TestStatus.unannotated) {
     expect(test.linkedBehaviors).toHaveLength(0)
   }
+
+  if (test.status !== TestStatus.missing) {
+    expect(test.ciLink).not.toBe('')
+  }
 }
 
 export function testBehaviorIntegrity(behavior: Behavior) {


### PR DESCRIPTION
## Description

We can't use classname, source or any path to try and figure out what the proper CI link is for a test is, we have to depend on pure function name.

I also changed the way test status is determined.

What this means:
- They may be duplicate function names, so a few links should be wrong. This happens _very rarely_, and since this is not a deal breaking feature, we can live with it.
- It's hard to determine what ci link to choose anyway, because the same test function can be (and it happens often) a part of multiple CI jobs. Which one should I link to?

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a configuration update

## How Has This Been Tested?

A small addition to model unit tests.

## Checklist:

- [x] I have performed a self-review of this code and spelling
- [x] I have added comments in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

