### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/deploy-fe.yml
+++ b/.github/workflows/deploy-fe.yml
@@ -69,7 +69,7 @@ jobs:
       #
       - name: Artifacts
         id: upload-artifact-build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifact-fe
           path: |
@@ -144,7 +144,7 @@ jobs:
       #
       # Download artifact for e2e testing
       #
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download-artifact
         with:
           name: artifact-fe
@@ -161,7 +161,7 @@ jobs:
       # Upload cypress video to artifact
       #
       - name: Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         id: upload-artifact-cypress
         with:
           name: artifact-fe
@@ -199,7 +199,7 @@ jobs:
       #
       # Download the artifact
       #
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact-fe
 


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/